### PR TITLE
Fix duplicate HTML paragraph tag in README footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To merge the color theme into your current settings copy the [`nord`](https://gi
 ### Contribution
 Please report issues/bugs, feature requests and suggestions for improvements to the [issue tracker](https://github.com/arcticicestudio/nord-xresources/issues).
 
-<p align="center"><img src=" <p align="center"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/develop/assets/images/nord/repository-footer-separator.svg?sanitize=true" /></p>
+<p align="center"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/develop/assets/images/nord/repository-footer-separator.svg?sanitize=true" /></p>
 
 <p align="center">Copyright &copy; 2016-present Arctic Ice Studio</p>
 


### PR DESCRIPTION
There was an extra p tag in front of the bottom image